### PR TITLE
handle edge-cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,13 @@ This plugin supports these configuration:
   default true)
 
 * `cacheKeyIncludeHost`: (optional) Specifies if the host should be included in the cache key. (default true)
-* `cacheKeyIncludeRemoteAddress`: (optional) Speifics if the remote request address should be included in the cache key (default false)
+* `cacheKeyIncludeRemoteAddress`: (optional) Speifics if the remote request address should be included in the cache
+  key (default false)
 * `cacheKeyIncludeHeaders`: (optional) Specifies if the headers should be included in the cache key. (default false)
 * `cacheKeyHeaders`: (optional) An array of specific headers to be included in the cache key when
-  CacheKeyIncludeHeaders is true. (ie: ["User-Agent"]) - note some headers are ALWAYS blacklisted, and even if you list them here, they will still not be cached `Authorization: *, Set-Cookie: *, Cache-Control: no-store, Pragma: no-cache, Expires: -1 (date in the past)`
+  CacheKeyIncludeHeaders is true. (ie: ["User-Agent"]) - note some headers are ALWAYS blacklisted, and even if you list
+  them here, they will still not be
+  cached `Authorization: *, Set-Cookie: *, Cache-Control: no-store, Pragma: no-cache, Expires: -1 (date in the past)`
 
 **Note**: body of every (non-cached) request will be buffered in memory while the request is in-flight (i.e.: during the
 security

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ time.
 *NEW*: Caching modsecurity responses helps to minimize the overhead of processing every request and improves
 performance. By generating cache keys based on various factors like the request method, host, request URI, headers, and
 remote address, we can ensure that different requests are treated uniquely, while similar requests can be served from
-the cache. This approach helps in reducing the load on the modsecurity instance and improves response times for
+the plugins cache. This approach helps in reducing the load on the modsecurity instance and improves response times for
 requests. You can tune this to your liking but we recommend the following options:
 
 ## Configuration
@@ -77,10 +77,13 @@ This plugin supports these configuration:
 * `cacheKeyIncludeRemoteAddress`: (optional) Speifics if the remote request address should be included in the cache
   key (default false)
 * `cacheKeyIncludeHeaders`: (optional) Specifies if the headers should be included in the cache key. (default false)
-* `cacheKeyHeaders`: (optional) An array of specific headers to be included in the cache key when
-  CacheKeyIncludeHeaders is true. (ie: ["User-Agent"]) - note some headers are ALWAYS blacklisted, and even if you list
-  them here, they will still not be
-  cached `Authorization: *, Set-Cookie: *, Cache-Control: no-store, Pragma: no-cache, Expires: -1 (date in the past)`
+* `cacheKeyHeaders`: (optional) An array of specific headers to be included in the cache key when CacheKeyIncludeHeaders is true. (ie: ["User-Agent"]) 
+
+note some headers are ALWAYS blacklisted, and even if you list
+them here, they will still not be cached:
+```
+Authorization: *, Set-Cookie: *, Cache-Control: no-store, Pragma: no-cache, Expires: -1 (date in the past)
+```
 
 **Note**: body of every (non-cached) request will be buffered in memory while the request is in-flight (i.e.: during the
 security

--- a/modsecurity.go
+++ b/modsecurity.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"github.com/patrickmn/go-cache"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -183,7 +182,7 @@ func (a *Modsecurity) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			http.Error(rw, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
-		req.Body = ioutil.NopCloser(bytes.NewBuffer(reqBodyCopy.Bytes()))
+		req.Body = io.NopCloser(bytes.NewBuffer(reqBodyCopy.Bytes()))
 	}
 
 	var wg sync.WaitGroup
@@ -198,7 +197,7 @@ func (a *Modsecurity) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		defer wg.Done()
 		reqCopy := req.Clone(req.Context())
 		if req.Body != nil {
-			reqCopy.Body = ioutil.NopCloser(bytes.NewBuffer(reqBodyCopy.Bytes()))
+			reqCopy.Body = io.NopCloser(bytes.NewBuffer(reqBodyCopy.Bytes()))
 		}
 		resp, respErr = a.HandleCacheAndForwardRequest(reqCopy)
 	}()

--- a/modsecurity.go
+++ b/modsecurity.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 )
 
@@ -170,9 +169,6 @@ func (a *Modsecurity) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	var reqBodyCopy *bytes.Buffer
-	var reqErr error
-
 	// Check for a non-zero Content-Length or the presence of a body
 	hasBody, err := requestHasBody(req)
 	if err != nil {
@@ -182,31 +178,13 @@ func (a *Modsecurity) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	if hasBody {
-		reqErr = a.HandleRequestBodyMaxSize(rw, req)
+		reqErr := a.HandleRequestBodyMaxSize(rw, req)
 		if reqErr != nil {
-			return
-		}
-
-		isChunked := req.TransferEncoding != nil && strings.EqualFold(req.TransferEncoding[0], "chunked")
-		if isChunked {
-			reqBodyCopy, reqErr = copyRequestBodyChunked(req)
-		} else {
-			reqBodyCopy, reqErr = copyRequestBody(req)
-		}
-
-		if reqErr != nil {
-			a.logger.Printf("Failed to copy request body: %s", reqErr.Error())
-			http.Error(rw, "Internal Server Error", http.StatusInternalServerError)
 			return
 		}
 	}
 
-	// Handle the cache layer.
-	reqCopy := req.Clone(req.Context())
-	if reqBodyCopy != nil {
-		reqCopy.Body = io.NopCloser(bytes.NewBuffer(reqBodyCopy.Bytes()))
-	}
-	resp, respErr := a.HandleCacheAndForwardRequest(reqCopy)
+	resp, respErr := a.HandleCacheAndForwardRequest(req)
 
 	if respErr != nil {
 		return
@@ -220,48 +198,6 @@ func (a *Modsecurity) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	a.next.ServeHTTP(rw, req)
-}
-
-const maxChunkSize = 32 * 1024 // 32 KB
-
-// copyRequestBody creates a copy of the request body to avoid data races and stream issues.
-func copyRequestBody(req *http.Request) (*bytes.Buffer, error) {
-	// If the request body is empty, return nil.
-	if req.Body == nil {
-		return nil, nil
-	}
-	// Create a new buffer and copy the request body into it.
-	reqBodyCopy := new(bytes.Buffer)
-	_, err := io.Copy(reqBodyCopy, req.Body)
-	if err != nil {
-		return nil, err
-	}
-	// Set the request body to a NopCloser with the copied bytes, so it can be read multiple times.
-	req.Body = io.NopCloser(bytes.NewBuffer(reqBodyCopy.Bytes()))
-	return reqBodyCopy, nil
-}
-
-func copyRequestBodyChunked(req *http.Request) (*bytes.Buffer, error) {
-	var buf bytes.Buffer
-	reader := req.Body
-
-	chunk := make([]byte, maxChunkSize)
-	for {
-		n, err := reader.Read(chunk)
-		if err != nil && err != io.EOF {
-			return nil, err
-		}
-
-		if n == 0 {
-			break
-		}
-
-		if _, writeErr := buf.Write(chunk[:n]); writeErr != nil {
-			return nil, writeErr
-		}
-	}
-
-	return &buf, nil
 }
 
 func requestHasBody(req *http.Request) (bool, error) {

--- a/modsecurity_test.go
+++ b/modsecurity_test.go
@@ -93,7 +93,7 @@ func TestModsecurity_ServeHTTP(t *testing.T) {
 		{
 			name: "Reject too big payloads",
 			request: http.Request{
-				Body: generateLargeBody(5025),
+				Body: generateLargeBody(1025),
 			},
 			wafResponse: response{
 				StatusCode: 200,


### PR DESCRIPTION
- fix some deprecations with ioutil.NopCloser 
- refactor our ServeHTTP to run in sequence (security, to prevent memory overflows on large bodies) - removed waitgroups
- handle malformed requests (content-length of 0, but has a body) 